### PR TITLE
DALE-813 Use Error Mappers to return Structured Errors

### DIFF
--- a/llms/anthropic/anthropicllm.go
+++ b/llms/anthropic/anthropicllm.go
@@ -404,10 +404,12 @@ func handleAIMessage(msg llms.MessageContent) (anthropicclient.ChatMessage, erro
 	if textContent, ok := msg.Parts[0].(llms.TextContent); ok {
 		return anthropicclient.ChatMessage{
 			Role: RoleAssistant,
-			Content: []anthropicclient.Content{&anthropicclient.TextContent{
-				Type: "text",
-				Text: textContent.Text,
-			}},
+			Content: []anthropicclient.Content{
+				&anthropicclient.TextContent{
+					Type: "text",
+					Text: textContent.Text,
+				},
+			},
 		}, nil
 	}
 	return anthropicclient.ChatMessage{}, fmt.Errorf("anthropic: %w for AI message", ErrInvalidContentType)

--- a/llms/anthropic/internal/anthropicclient/completions.go
+++ b/llms/anthropic/internal/anthropicclient/completions.go
@@ -73,7 +73,7 @@ func (c *Client) createCompletion(ctx context.Context, payload *completionPayloa
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, c.decodeError(resp)
+		return nil, MapError(c.decodeError(resp), resp.StatusCode)
 	}
 
 	if payload.StreamingFunc != nil {

--- a/llms/anthropic/internal/anthropicclient/errors.go
+++ b/llms/anthropic/internal/anthropicclient/errors.go
@@ -1,4 +1,4 @@
-package anthropic
+package anthropicclient
 
 import (
 	"strings"
@@ -58,7 +58,7 @@ var anthropicErrorMappings = []errorMapping{
 }
 
 // MapError maps Anthropic-specific errors to standardized error codes.
-func MapError(err error) error {
+func MapError(err error, statusCode int) error {
 	if err == nil {
 		return nil
 	}
@@ -69,7 +69,7 @@ func MapError(err error) error {
 	for _, mapping := range anthropicErrorMappings {
 		for _, pattern := range mapping.patterns {
 			if strings.Contains(errStr, pattern) {
-				return llms.NewError(mapping.code, "anthropic", mapping.message).WithCause(err)
+				return llms.NewError(mapping.code, "anthropic", mapping.message, statusCode).WithCause(err)
 			}
 		}
 	}

--- a/llms/bedrock/internal/bedrockclient/bedrockclient_integration_test.go
+++ b/llms/bedrock/internal/bedrockclient/bedrockclient_integration_test.go
@@ -831,7 +831,7 @@ func testCreateAi21CompletionWithMock(ctx context.Context, client *mockBedrockCl
 
 	resp, err := client.InvokeModel(ctx, modelInput)
 	if err != nil {
-		return nil, err
+		return nil, MapError(err)
 	}
 
 	var output ai21TextGenerationOutput
@@ -887,7 +887,7 @@ func testCreateAmazonCompletionWithMock(ctx context.Context, client *mockBedrock
 
 	resp, err := client.InvokeModel(ctx, modelInput)
 	if err != nil {
-		return nil, err
+		return nil, MapError(err)
 	}
 
 	var output amazonTextGenerationOutput
@@ -953,7 +953,7 @@ func testCreateAnthropicCompletionWithMock(ctx context.Context, client *mockBedr
 
 	resp, err := client.InvokeModel(ctx, modelInput)
 	if err != nil {
-		return nil, err
+		return nil, MapError(err)
 	}
 
 	var output anthropicTextGenerationOutput
@@ -1011,7 +1011,7 @@ func testCreateCohereCompletionWithMock(ctx context.Context, client *mockBedrock
 
 	resp, err := client.InvokeModel(ctx, modelInput)
 	if err != nil {
-		return nil, err
+		return nil, MapError(err)
 	}
 
 	var output cohereTextGenerationOutput
@@ -1060,7 +1060,7 @@ func testCreateMetaCompletionWithMock(ctx context.Context, client *mockBedrockCl
 
 	resp, err := client.InvokeModel(ctx, modelInput)
 	if err != nil {
-		return nil, err
+		return nil, MapError(err)
 	}
 
 	var output metaTextGenerationOutput

--- a/llms/bedrock/internal/bedrockclient/errors.go
+++ b/llms/bedrock/internal/bedrockclient/errors.go
@@ -1,4 +1,4 @@
-package bedrock
+package bedrockclient
 
 import (
 	"strings"
@@ -69,7 +69,7 @@ func MapError(err error) error {
 	for _, mapping := range bedrockErrorMappings {
 		for _, pattern := range mapping.patterns {
 			if strings.Contains(errStr, pattern) {
-				return llms.NewError(mapping.code, "bedrock", mapping.message).WithCause(err)
+				return llms.NewError(mapping.code, "bedrock", mapping.message, 0).WithCause(err)
 			}
 		}
 	}

--- a/llms/bedrock/internal/bedrockclient/provider_ai21.go
+++ b/llms/bedrock/internal/bedrockclient/provider_ai21.go
@@ -109,7 +109,7 @@ func createAi21Completion(ctx context.Context, client *bedrockruntime.Client, mo
 
 	resp, err := client.InvokeModel(ctx, &modelInput)
 	if err != nil {
-		return nil, err
+		return nil, MapError(err)
 	}
 
 	var output ai21TextGenerationOutput

--- a/llms/bedrock/internal/bedrockclient/provider_amazon.go
+++ b/llms/bedrock/internal/bedrockclient/provider_amazon.go
@@ -87,7 +87,7 @@ func createAmazonCompletion(ctx context.Context,
 	}
 	resp, err := client.InvokeModel(ctx, modelInput)
 	if err != nil {
-		return nil, err
+		return nil, MapError(err)
 	}
 
 	var output amazonTextGenerationOutput

--- a/llms/bedrock/internal/bedrockclient/provider_anthropic.go
+++ b/llms/bedrock/internal/bedrockclient/provider_anthropic.go
@@ -205,7 +205,7 @@ func createAnthropicCompletion(ctx context.Context,
 	}
 	resp, err := client.InvokeModel(ctx, modelInput)
 	if err != nil {
-		return nil, err
+		return nil, MapError(err)
 	}
 
 	var output anthropicTextGenerationOutput

--- a/llms/bedrock/internal/bedrockclient/provider_cohere.go
+++ b/llms/bedrock/internal/bedrockclient/provider_cohere.go
@@ -92,7 +92,7 @@ func createCohereCompletion(ctx context.Context,
 	}
 	resp, err := client.InvokeModel(ctx, modelInput)
 	if err != nil {
-		return nil, err
+		return nil, MapError(err)
 	}
 
 	var output cohereTextGenerationOutput

--- a/llms/bedrock/internal/bedrockclient/provider_meta.go
+++ b/llms/bedrock/internal/bedrockclient/provider_meta.go
@@ -73,7 +73,7 @@ func createMetaCompletion(ctx context.Context,
 
 	resp, err := client.InvokeModel(ctx, modelInput)
 	if err != nil {
-		return nil, err
+		return nil, MapError(err)
 	}
 
 	var output metaTextGenerationOutput

--- a/llms/bedrock/internal/bedrockclient/provider_nova.go
+++ b/llms/bedrock/internal/bedrockclient/provider_nova.go
@@ -169,7 +169,7 @@ func createNovaCompletion(ctx context.Context,
 	}
 	resp, err := client.InvokeModel(ctx, modelInput)
 	if err != nil {
-		return nil, err
+		return nil, MapError(err)
 	}
 
 	output, err := parseNovaResponseBody(resp.Body)

--- a/llms/cohere/internal/cohereclient/errors.go
+++ b/llms/cohere/internal/cohereclient/errors.go
@@ -1,4 +1,4 @@
-package cohere
+package cohereclient
 
 import (
 	"strings"
@@ -58,7 +58,7 @@ var cohereErrorMappings = []errorMapping{
 }
 
 // MapError maps Cohere-specific errors to standardized error codes.
-func MapError(err error) error {
+func MapError(err error, statusCode int) error {
 	if err == nil {
 		return nil
 	}
@@ -69,7 +69,7 @@ func MapError(err error) error {
 	for _, mapping := range cohereErrorMappings {
 		for _, pattern := range mapping.patterns {
 			if strings.Contains(errStr, pattern) {
-				return llms.NewError(mapping.code, "cohere", mapping.message).WithCause(err)
+				return llms.NewError(mapping.code, "cohere", mapping.message, statusCode).WithCause(err)
 			}
 		}
 	}

--- a/llms/errors.go
+++ b/llms/errors.go
@@ -63,12 +63,21 @@ type Error struct {
 
 	// Cause is the underlying error, if any.
 	Cause error
+
+	// HTTPStatusCode is the HTTP status code returned with the error, if applicable.
+	HTTPStatusCode int
 }
 
 // Error implements the error interface.
 func (e *Error) Error() string {
 	if e.Provider != "" {
+		if e.HTTPStatusCode > 0 {
+			return fmt.Sprintf("%s: %s: %s (HTTP %d)", e.Provider, e.Code, e.Message, e.HTTPStatusCode)
+		}
 		return fmt.Sprintf("%s: %s: %s", e.Provider, e.Code, e.Message)
+	}
+	if e.HTTPStatusCode > 0 {
+		return fmt.Sprintf("%s: %s (HTTP %d)", e.Code, e.Message, e.HTTPStatusCode)
 	}
 	return fmt.Sprintf("%s: %s", e.Code, e.Message)
 }
@@ -101,12 +110,13 @@ func (e *Error) Is(target error) bool {
 }
 
 // NewError creates a new standardized error.
-func NewError(code ErrorCode, provider, message string) *Error {
+func NewError(code ErrorCode, provider, message string, httpStatusCode int) *Error {
 	return &Error{
-		Code:     code,
-		Provider: provider,
-		Message:  message,
-		Details:  make(map[string]interface{}),
+		Code:           code,
+		Provider:       provider,
+		Message:        message,
+		Details:        make(map[string]interface{}),
+		HTTPStatusCode: httpStatusCode,
 	}
 }
 

--- a/llms/errors_mapper.go
+++ b/llms/errors_mapper.go
@@ -144,7 +144,7 @@ func (m *ErrorMapper) WrapError(err error) error {
 		}
 	}
 
-	return NewError(code, m.provider, message).WithCause(err)
+	return NewError(code, m.provider, message, 0).WithCause(err)
 }
 
 // Map is an alias for WrapError for consistency with provider error mappers.

--- a/llms/googleai/vertex/vertex.go
+++ b/llms/googleai/vertex/vertex.go
@@ -15,6 +15,7 @@ import (
 	"cloud.google.com/go/vertexai/genai"
 	"github.com/vendasta/langchaingo/internal/imageutil"
 	"github.com/vendasta/langchaingo/llms"
+	googleaierrors "github.com/vendasta/langchaingo/llms/googleai/errors"
 	"google.golang.org/api/iterator"
 )
 
@@ -306,16 +307,24 @@ func generateFromSingleMessage(
 		// the complete response with a list of candidates.
 		resp, err := model.GenerateContent(ctx, convertedParts...)
 		if err != nil {
-			return nil, err
+			return nil, googleaierrors.MapError(err)
 		}
 
 		if len(resp.Candidates) == 0 {
 			return nil, ErrNoContentInResponse
 		}
-		return convertCandidates(resp.Candidates, resp.UsageMetadata)
+		response, err := convertCandidates(resp.Candidates, resp.UsageMetadata)
+		if err != nil {
+			return nil, googleaierrors.MapError(err)
+		}
+		return response, nil
 	}
 	iter := model.GenerateContentStream(ctx, convertedParts...)
-	return convertAndStreamFromIterator(ctx, iter, opts)
+	response, err := convertAndStreamFromIterator(ctx, iter, opts)
+	if err != nil {
+		return nil, googleaierrors.MapError(err)
+	}
+	return response, nil
 }
 
 func generateFromMessages(

--- a/llms/mistral/errors.go
+++ b/llms/mistral/errors.go
@@ -69,7 +69,7 @@ func MapError(err error) error {
 	for _, mapping := range mistralErrorMappings {
 		for _, pattern := range mapping.patterns {
 			if strings.Contains(errStr, pattern) {
-				return llms.NewError(mapping.code, "mistral", mapping.message).WithCause(err)
+				return llms.NewError(mapping.code, "mistral", mapping.message, 0).WithCause(err)
 			}
 		}
 	}

--- a/llms/openai/internal/openaiclient/chat.go
+++ b/llms/openai/internal/openaiclient/chat.go
@@ -524,10 +524,9 @@ func (c *Client) createChat(ctx context.Context, payload *ChatRequest) (*ChatCom
 		// status code.
 		var errResp errorMessage
 		if err := json.NewDecoder(r.Body).Decode(&errResp); err != nil {
-			return nil, errors.New(msg)
+			return nil, MapError(errors.New(msg), r.StatusCode)
 		}
-
-		return nil, fmt.Errorf("%s: %s", msg, errResp.Error.Message)
+		return nil, MapError(fmt.Errorf("%s: %s", msg, errResp.Error.Message), r.StatusCode)
 	}
 	if payload.StreamingFunc != nil || payload.StreamingReasoningFunc != nil {
 		return parseStreamingChatResponse(ctx, r, payload)

--- a/llms/openai/internal/openaiclient/errors.go
+++ b/llms/openai/internal/openaiclient/errors.go
@@ -1,4 +1,4 @@
-package openai
+package openaiclient
 
 import (
 	"strings"
@@ -58,7 +58,7 @@ var openaiErrorMappings = []errorMapping{
 }
 
 // MapError maps OpenAI-specific errors to standardized error codes.
-func MapError(err error) error {
+func MapError(err error, statusCode int) error {
 	if err == nil {
 		return nil
 	}
@@ -69,7 +69,7 @@ func MapError(err error) error {
 	for _, mapping := range openaiErrorMappings {
 		for _, pattern := range mapping.patterns {
 			if strings.Contains(errStr, pattern) {
-				return llms.NewError(mapping.code, "openai", mapping.message).WithCause(err)
+				return llms.NewError(mapping.code, "openai", mapping.message, statusCode).WithCause(err)
 			}
 		}
 	}


### PR DESCRIPTION
This package defines its own structured error type, but errors returned from LLM calls were never converted to this error type.

These providers each had their own MapError method that can be used to convert the error to this structured type.  In order to call this method right after the LLM Request was made, I moved the errors file into the client folder for most models.

This structured error type didn't include a field for the HTTP status code, which is one of the things we wanted to track. so I added it as a field.

For OpenAI, we map the error and include the status code.
For GoogleAIs that use GRPC, we try to parse the error as a GRPC error, and convert that status code to the equivalent HTTP status code.

For the other models, I just did my best based on how the request was being made.

With this in place, when an error is returned from `GenerateContent`, we can parse this structured error and include more tags in our monitoring

@vendasta/dont-ask-lets-experiment 
