### PR TITLE
Add GPT-5 reasoning effort support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ lint-all:
 lint-deps:
 	@command -v golangci-lint >/dev/null 2>&1 || { \
 		echo >&2 "golangci-lint not found. Installing..."; \
-		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.55.2; \
 		command -v golangci-lint >/dev/null 2>&1 || { \
 			echo >&2 "Failed to detect golangci-lint after installation. Please check your Go installation and PATH."; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ lint-all:
 lint-deps:
 	@command -v golangci-lint >/dev/null 2>&1 || { \
 		echo >&2 "golangci-lint not found. Installing..."; \
-		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.3.0; \
 		command -v golangci-lint >/dev/null 2>&1 || { \
 			echo >&2 "Failed to detect golangci-lint after installation. Please check your Go installation and PATH."; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ lint-all:
 lint-deps:
 	@command -v golangci-lint >/dev/null 2>&1 || { \
 		echo >&2 "golangci-lint not found. Installing..."; \
-		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.3.0; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest; \
 		command -v golangci-lint >/dev/null 2>&1 || { \
 			echo >&2 "Failed to detect golangci-lint after installation. Please check your Go installation and PATH."; \
 			exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ lint-all:
 lint-deps:
 	@command -v golangci-lint >/dev/null 2>&1 || { \
 		echo >&2 "golangci-lint not found. Installing..."; \
-		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.55.2; \
+		go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest; \
 		command -v golangci-lint >/dev/null 2>&1 || { \
 			echo >&2 "Failed to detect golangci-lint after installation. Please check your Go installation and PATH."; \
 			exit 1; \

--- a/llms/openai/openaillm.go
+++ b/llms/openai/openaillm.go
@@ -210,12 +210,11 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 		}
 	}
 
-	// Extract reasoning effort for thinking models
+	// Extract reasoning effort for GPT-5 models only
 	// Note: OpenAI o1/o3 models have built-in reasoning and don't support reasoning_effort parameter
-	// This is kept for future models that might support it (like GPT-5)
+	// GPT-5 models support the reasoning_effort parameter to control thinking intensity
 	var reasoningEffort string
-	// Commented out for now since current o1 models don't support this parameter
-	/*
+	if isGPT5Model(effectiveModel) {
 		if opts.Metadata != nil {
 			if config, ok := opts.Metadata["thinking_config"].(*llms.ThinkingConfig); ok {
 				// Map thinking mode to reasoning effort
@@ -226,6 +225,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 					reasoningEffort = "medium"
 				case llms.ThinkingModeHigh:
 					reasoningEffort = "high"
+					// ThinkingModeNone and ThinkingModeAuto don't set the parameter
 				}
 
 				// Handle streaming for thinking
@@ -243,7 +243,7 @@ func (o *LLM) GenerateContent(ctx context.Context, messages []llms.MessageConten
 				}
 			}
 		}
-	*/
+	}
 
 	// Filter out internal metadata that shouldn't be sent to API
 	apiMetadata := make(map[string]any)
@@ -499,4 +499,10 @@ func toolCallFromToolCall(tc llms.ToolCall) openaiclient.ToolCall {
 			Arguments: tc.FunctionCall.Arguments,
 		},
 	}
+}
+
+// isGPT5Model checks if a model is a GPT-5 model that supports reasoning_effort parameter.
+func isGPT5Model(model string) bool {
+	modelLower := strings.ToLower(model)
+	return strings.HasPrefix(modelLower, "gpt-5")
 }


### PR DESCRIPTION
Enables `reasoning_effort` parameter for GPT-5 models via `ThinkingMode` configuration.

Maps `ThinkingMode` values (Low, Medium, High) to OpenAI's `reasoning_effort` parameter. Only applied to GPT-5 models; o1/o3 models unaffected.

@vendasta/dont-ask-lets-experiment 