### PR TITLE
Fix Gemini 3+ tool calling by preserving ThoughtSignature

### DIFF
--- a/examples/llmsummarization-chain-example/go.mod
+++ b/examples/llmsummarization-chain-example/go.mod
@@ -1,6 +1,6 @@
 module github.com/vendasta/langchaingo/examples/llmsummarization-chain-example
 
-go 1.24.3
+go 1.24.4
 
 require github.com/vendasta/langchaingo v0.1.14-pre.4
 
@@ -14,7 +14,7 @@ require (
 	cloud.google.com/go/iam v1.2.2 // indirect
 	cloud.google.com/go/longrunning v0.6.2 // indirect
 	cloud.google.com/go/vertexai v0.12.0 // indirect
-	github.com/AssemblyAI/assemblyai-go-sdk v1.3.0 // indirect
+	github.com/AssemblyAI/assemblyai-go-sdk v1.10.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect

--- a/examples/llmsummarization-chain-example/go.sum
+++ b/examples/llmsummarization-chain-example/go.sum
@@ -21,6 +21,7 @@ filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/AssemblyAI/assemblyai-go-sdk v1.3.0 h1:AtOVgGxUycvK4P4ypP+1ZupecvFgnfH+Jsum0o5ILoU=
 github.com/AssemblyAI/assemblyai-go-sdk v1.3.0/go.mod h1:H0naZbvpIW49cDA5ZZ/gggeXqi7ojSGB1mqshRk6kNE=
+github.com/AssemblyAI/assemblyai-go-sdk v1.10.0/go.mod h1:dwv8jDdg+UKPU9ClZzhQNXIVj3Yw68IaTVRuyKRLigw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=

--- a/examples/mistral-summarization-example/go.mod
+++ b/examples/mistral-summarization-example/go.mod
@@ -1,11 +1,11 @@
 module github.com/vendasta/langchaingo/examples/mistral-summarization-example
 
-go 1.24.3
+go 1.24.4
 
 require github.com/vendasta/langchaingo v0.1.14-pre.4
 
 require (
-	github.com/AssemblyAI/assemblyai-go-sdk v1.3.0 // indirect
+	github.com/AssemblyAI/assemblyai-go-sdk v1.10.0 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
 	github.com/Masterminds/semver/v3 v3.2.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.2.3 // indirect

--- a/examples/mistral-summarization-example/go.sum
+++ b/examples/mistral-summarization-example/go.sum
@@ -21,6 +21,7 @@ filippo.io/edwards25519 v1.1.0 h1:FNf4tywRC1HmFuKW5xopWpigGjJKiJSV0Cqo0cJWDaA=
 filippo.io/edwards25519 v1.1.0/go.mod h1:BxyFTGdWcka3PhytdK4V28tE5sGfRvvvRV7EaN4VDT4=
 github.com/AssemblyAI/assemblyai-go-sdk v1.3.0 h1:AtOVgGxUycvK4P4ypP+1ZupecvFgnfH+Jsum0o5ILoU=
 github.com/AssemblyAI/assemblyai-go-sdk v1.3.0/go.mod h1:H0naZbvpIW49cDA5ZZ/gggeXqi7ojSGB1mqshRk6kNE=
+github.com/AssemblyAI/assemblyai-go-sdk v1.10.0/go.mod h1:dwv8jDdg+UKPU9ClZzhQNXIVj3Yw68IaTVRuyKRLigw=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/Masterminds/goutils v1.1.1 h1:5nUrii3FMTL5diU80unEVvNevw1nH4+ZV4DSLVJLSYI=
 github.com/Masterminds/goutils v1.1.1/go.mod h1:8cTjp+g8YejhMuvIA5y2vz3BpJxksy863GQaJW2MFNU=

--- a/go.mod
+++ b/go.mod
@@ -167,7 +167,6 @@ require (
 	github.com/xdg-go/scram v1.1.2 // indirect
 	github.com/xdg-go/stringprep v1.0.4 // indirect
 	github.com/youmark/pkcs8 v0.0.0-20240726163527-a2c0da244d78 // indirect
-
 )
 
 // Database drivers - indirect

--- a/llms/generatecontent.go
+++ b/llms/generatecontent.go
@@ -102,6 +102,9 @@ type ToolCall struct {
 	Type string `json:"type"`
 	// FunctionCall is the function call to be executed.
 	FunctionCall *FunctionCall `json:"function,omitempty"`
+	// ThoughtSignature is an opaque signature for Gemini 3+ models that must be
+	// preserved when echoing back function calls. Required for tool calling to work.
+	ThoughtSignature []byte `json:"thought_signature,omitempty"`
 }
 
 func (ToolCall) isPart() {}

--- a/llms/googleaiv2/googleai.go
+++ b/llms/googleaiv2/googleai.go
@@ -305,7 +305,7 @@ func convertCandidates(candidates []*genai.Candidate, usage *genai.GenerateConte
 	for i, candidate := range candidates {
 		var textContent string
 		var toolCalls []llms.ToolCall
-		
+
 		// Use the response's Text() method if available (more reliable, handles thoughts correctly)
 		// For multi-candidate responses, we need to extract text per candidate
 		if response != nil && i == 0 {
@@ -349,6 +349,8 @@ func convertCandidates(candidates []*genai.Candidate, usage *genai.GenerateConte
 							Name:      part.FunctionCall.Name,
 							Arguments: string(b),
 						},
+						// Preserve ThoughtSignature for Gemini 3+ models - required for tool calling
+						ThoughtSignature: part.ThoughtSignature,
 					}
 					toolCalls = append(toolCalls, toolCall)
 				}
@@ -446,7 +448,10 @@ func convertParts(parts []llms.ContentPart) ([]*genai.Part, error) {
 				Name: fc.Name,
 				Args: argsMap,
 			}
-			out = &genai.Part{FunctionCall: functionCall}
+			out = &genai.Part{
+				FunctionCall:     functionCall,
+				ThoughtSignature: p.ThoughtSignature, // Required for Gemini 3+ tool calling
+			}
 		case llms.ToolCallResponse:
 			functionResponse := &genai.FunctionResponse{
 				Name: p.Name,


### PR DESCRIPTION
Gemini 3+ models require a ThoughtSignature to be preserved when echoing back function calls. Without this, the API rejects tool responses with:

```
Error 400: Function call is missing a thought_signature in functionCall parts.
```

- This PR adds support for preserving the ThoughtSignature field through the tool call round-trip.


@vendasta/gosdks 